### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 clui
 =============
 
+[![Inline docs](http://inch-ci.org/github/nathanpeck/clui.svg?branch=master)](http://inch-ci.org/github/nathanpeck/clui)
+
 This is a Node.js toolkit for quickly building nice looking command line interfaces which can respond to changing terminal sizes. It also includes the following easy to use components:
 
 * Gauges


### PR DESCRIPTION
Hi Nathan,


I want to propose to add this badge to the README to show off inline-documentation: [![Inline docs](http://inch-ci.org/github/nathanpeck/clui.svg)](http://inch-ci.org/github/nathanpeck/clui)

I do get that you are not big on badges in your README, but bear with me:

The badge links to [Inch CI](http://inch-ci.org) and shows an evaluation by [InchJS](http://trivelop.de/inchjs), a project that tries to raise the visibility of inline-docs. This little project of mine is about *engagement*. And for me, while testing and code coverage are important, inline-docs are the humanly engaging factor in Open Source. This project is about making people less adverse to jumping into the code and seeing whats happening, because they are not left alone while doing so. I know that, because I put off reading other people's code way too long in my life.

I would really like to roll out support for JS over the coming weeks (early adopters are [forever](https://github.com/foreverjs/forever), [node-sass](https://github.com/sass/node-sass) and [Shipit](https://github.com/shipitjs/shipit)). And although this is "only" a passion project, I really would like to hear your thoughts, critique and suggestions. Your status page is http://inch-ci.org/github/nathanpeck/clui

While a polite "No thank you" is absolutely okay, I am curious: What do you think about this?