### PR TITLE
Allow for the extra new line from Line#output to be suppressed.

### DIFF
--- a/lib/clui.js
+++ b/lib/clui.js
@@ -252,10 +252,25 @@ var helpers = {
   },
 
   // Chainable wrapper for line content
-  Line: function (defaultBuffer) {
+  Line: function (defaultBuffer, opts) {
     var lineContent = "";
     var self = this;
-    self.defaultBuffer = defaultBuffer;
+    if(defaultBuffer instanceof helpers.LineBuffer) {
+        self.defaultBuffer = defaultBuffer;
+    }
+
+    // Allow the user to send in options as the first argument if they aren't
+    // supplying a default buffer.
+    self.options = self.defaultBuffer ?
+        opts:
+        defaultBuffer;
+
+    self.options = self.options || {};
+
+    // Default new line option to true to maintain old behavior.
+    if(!self.options.hasOwnProperty('newLine')) {
+        self.options.newLine = true;
+    }
 
     // Put text in the line
     this.text = function (text, styles) {
@@ -324,7 +339,7 @@ var helpers = {
 
     // Output a line directly to the screen.
     this.output = function () {
-      process.stdout.write(lineContent+"\n");
+      process.stdout.write(lineContent + (self.options.newLine ? '\n' : ''));
       return self;
     };
     


### PR DESCRIPTION
This is the technique I was describing to resolve #8 

There's other ways to do this, but this should maintain backwards compatibility with how it was working while offering the ability to suppress the additional new line from Line#output.
