### PR TITLE
Corrected character count in gauge

### DIFF
--- a/lib/clui.js
+++ b/lib/clui.js
@@ -76,7 +76,7 @@ var helpers = {
         barColor = clc.red;
 
       return '['+
-        barColor(Array(barLength).join("|")) +  //The filled portion
+        barColor(Array(barLength+1).join("|")) +  //The filled portion
         Array(width+1-barLength).join("-") +    //The empty portion
       '] ' + clc.blackBright(suffix);
     }


### PR DESCRIPTION
Corrected the count of the symbols in the filled portion of a gauge.
The gauge could vary in width before the change.

**Example:**
Basically if you set width to 20 and had a value of 10, it would draw **9** pipes and 10 dashes which would only generate 19 characters.
When the bar was empty, it printed 20 dashes.
This is how the character count varied.

See: http://i.imgur.com/oczwChV.png
