### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ __Parameters__
 __Methods__
 
 * `start()` - Show the spinner on the screen.
-* `update(statusMessage)` - Update the status message that follows the spinner.
+* `message(statusMessage)` - Update the status message that follows the spinner.
 * `stop()` - Erase the spinner from the screen.
 
 *Note: The spinner is slightly different from other Clui controls in that it outputs


### PR DESCRIPTION
fixing typo: s/update/message/g

There is no method called 'update' on the spinner.